### PR TITLE
V2 route handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,6 +1548,8 @@ dependencies = [
 [[package]]
 name = "rapid-cli"
 version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92f8e5bed68eb225d464a95775908a31dafc027856a5319541a8ce98bc5f56f9"
 dependencies = [
  "clap",
  "colorful",
@@ -1568,9 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "rapid-cli"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92f8e5bed68eb225d464a95775908a31dafc027856a5319541a8ce98bc5f56f9"
+version = "0.4.5"
 dependencies = [
  "clap",
  "colorful",
@@ -1614,7 +1614,7 @@ dependencies = [
  "lazy_static",
  "log",
  "proc-macro2",
- "rapid-cli 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rapid-cli 0.4.4",
  "rapid-web-codegen",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "rapid-cli"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "clap",
  "colorful",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "rapid-web-codegen"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "include_dir",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "rapid-web"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "rapid-web"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/crates/rapid-cli/Cargo.toml
+++ b/crates/rapid-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapid-cli"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 description = "The CLI tool for the Rapid framework"
 repository = "https://github.com/DarrenBaldwin07/rapid"

--- a/crates/rapid-cli/Cargo.toml
+++ b/crates/rapid-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapid-cli"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 description = "The CLI tool for the Rapid framework"
 repository = "https://github.com/DarrenBaldwin07/rapid"

--- a/crates/rapid-cli/src/commands/new.rs
+++ b/crates/rapid-cli/src/commands/new.rs
@@ -67,44 +67,38 @@ pub fn parse_new_args(args: &ArgMatches) {
 				if val == &PathBuf::from("true") {
 					match arg {
 						"remix" => {
-							init_remix_template(current_working_directory);
+							init_remix_template(current_working_directory.clone());
 							did_find_match = true;
 							break;
 						}
 						"server" => {
-							init_server_template(current_working_directory, arg);
+							init_server_template(current_working_directory.clone(), arg);
 							did_find_match = true;
 							break;
 						}
 						_ => {
-							// If we got valid args but none of them actually matched on one of
-							// our support application types, we want to show the user an error message
-							println!(
-								"{}",
-								"No application type detected. Please use either --server or --remix".color(Color::Red)
-							);
+							// By default we should generate the remix template:
+							init_remix_template(current_working_directory.clone());
+							did_find_match = true;
 							break;
 						}
 					}
 				}
 			}
 			None => {
-				println!(
-					"{}",
-					"No application type detected. Please use either --server or --remix".color(Color::Red)
-				);
+				// By default we should generate the remix template:
+				init_remix_template(current_working_directory.clone());
+				did_find_match = true;
 				break;
 			}
 		}
 	}
 
 	// Check if we found a app type match
-	// If we did not than we want to show a log to the user
+	// If we did not than we want to simply generate the remix template
 	if !did_find_match {
-		println!(
-			"{}",
-			"No application type detected. Please use either --server or --remix".color(Color::Red)
-		);
+		// By default we should generate the remix template:
+		init_remix_template(current_working_directory);
 	}
 }
 

--- a/crates/rapid-cli/templates/remix/Cargo__toml
+++ b/crates/rapid-cli/templates/remix/Cargo__toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 futures-util = "0.3.28"
 include_dir = "0.7.3"
-rapid-web = "0.3.5"
+rapid-web = "0.3.6"
 
 # Rapid binary
 [[bin]]

--- a/crates/rapid-cli/templates/remix/Cargo__toml
+++ b/crates/rapid-cli/templates/remix/Cargo__toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 futures-util = "0.3.28"
 include_dir = "0.7.3"
-rapid-web = "0.3.6"
+rapid-web = "0.3.7"
 
 # Rapid binary
 [[bin]]

--- a/crates/rapid-cli/templates/remix/Cargo__toml
+++ b/crates/rapid-cli/templates/remix/Cargo__toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 futures-util = "0.3.28"
 include_dir = "0.7.3"
-rapid-web = "0.3.7"
+rapid-web = "0.3.8"
 
 # Rapid binary
 [[bin]]

--- a/crates/rapid-cli/templates/remix/app/api/routes/hello.rs
+++ b/crates/rapid-cli/templates/remix/app/api/routes/hello.rs
@@ -4,6 +4,6 @@ use rapid_web::rapid_web_codegen::rapid_handler;
 pub const ROUTE_KEY: &str = "hello";
 
 #[rapid_handler]
-pub async fn get() -> HttpResponse {
+pub async fn query() -> HttpResponse {
     HttpResponse::Ok().body("Hello from a RAPID rust endpoint!")
 }

--- a/crates/rapid-cli/templates/remix/app/api/routes/index.rs
+++ b/crates/rapid-cli/templates/remix/app/api/routes/index.rs
@@ -4,7 +4,7 @@ use rapid_web::{rapid_web_codegen::rapid_handler, welcome_view};
 pub const ROUTE_KEY: &str = "index";
 
 #[rapid_handler]
-pub async fn get() -> HttpResponse {
+pub async fn query() -> HttpResponse {
     HttpResponse::Ok()
     .content_type("text/html; charset=utf-8")
     .body(welcome_view)

--- a/crates/rapid-cli/templates/server/src/routes/index.rs
+++ b/crates/rapid-cli/templates/server/src/routes/index.rs
@@ -4,7 +4,7 @@ use rapid_web::{rapid_web_codegen::rapid_handler, welcome_view};
 pub const ROUTE_KEY: &str = "index";
 
 #[rapid_handler]
-pub async fn get() -> HttpResponse {
+pub async fn query() -> HttpResponse {
     HttpResponse::Ok()
     .content_type("text/html; charset=utf-8")
     .body(welcome_view)

--- a/crates/rapid-web-codegen/Cargo.toml
+++ b/crates/rapid-web-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapid-web-codegen"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Codegen utilities for the rapid framework."
 repository = "https://github.com/DarrenBaldwin07/rapid"

--- a/crates/rapid-web-codegen/src/lib.rs
+++ b/crates/rapid-web-codegen/src/lib.rs
@@ -425,6 +425,8 @@ fn generate_handler_tokens(route_handler: Handler, parsed_path: &str, handler_ty
 				.route(#rapid_routes_path, web::delete().to(#handler::#parsed_handler_type)#(#middleware_idents)*)
 			)
 		},
+		// Currently we still support declaring handlers with a very specific HTTP type (ex: `get` or `post` etc)
+		// ^^^ Eventually, what was described above
 		_ => quote!(.route(#rapid_routes_path, web::#parsed_handler_type().to(#handler::#parsed_handler_type)#(#middleware_idents)*))
 	}
 }
@@ -432,6 +434,7 @@ fn generate_handler_tokens(route_handler: Handler, parsed_path: &str, handler_ty
 /// Function for parsing a route fileer and making sure it contains a valid handler
 /// If it does, we want to push the valid handler to the handlers array
 fn parse_handlers(route_handlers: &mut Vec<RouteHandler>, file_contents: String, handler: Handler) {
+	// TODO: we need to depricate everything except for `query` and `mutation`
 	if file_contents.contains("async fn get") && validate_route_handler(&file_contents) {
 		route_handlers.push(RouteHandler::Get(handler))
 	} else if file_contents.contains("async fn post") && validate_route_handler(&file_contents) {

--- a/crates/rapid-web-codegen/src/lib.rs
+++ b/crates/rapid-web-codegen/src/lib.rs
@@ -52,6 +52,8 @@ struct Handler {
 
 // Currently, the rapid file-based router will only support GET, POST, DELETE, and PUT request formats (we could support patch if needed)
 enum RouteHandler {
+	Query(Handler),
+	Mutation(Handler),
 	Get(Handler),
 	Post(Handler),
 	Delete(Handler),
@@ -244,6 +246,8 @@ pub fn routes(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
 			RouteHandler::Delete(route_handler) => generate_handler_tokens(route_handler, parsed_path, "delete"),
 			RouteHandler::Put(route_handler) => generate_handler_tokens(route_handler, parsed_path, "put"),
 			RouteHandler::Patch(route_handler) => generate_handler_tokens(route_handler, parsed_path, "patch"),
+			RouteHandler::Query(route_handler) => generate_handler_tokens(route_handler, parsed_path, "query"),
+			RouteHandler::Mutation(route_handler) => generate_handler_tokens(route_handler, parsed_path, "mutation"),
 		})
 		.collect::<Vec<_>>();
 

--- a/crates/rapid-web-codegen/src/lib.rs
+++ b/crates/rapid-web-codegen/src/lib.rs
@@ -151,22 +151,7 @@ pub fn routes(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
 		// Check if the contents contain a valid rapid_web route and append them to the route handlers vec
 		// Routes are determined valid if they contain a function that starts with "async fn" and contains the "rapid_handler" attribute macro
-		if file_contents.contains("async fn get") && validate_route_handler(&file_contents) {
-			route_handlers.push(RouteHandler::Get(handler))
-		} else if file_contents.contains("async fn post") && validate_route_handler(&file_contents) {
-			route_handlers.push(RouteHandler::Post(handler))
-		} else if file_contents.contains("async fn delete") && validate_route_handler(&file_contents) {
-			route_handlers.push(RouteHandler::Delete(handler))
-		} else if file_contents.contains("async fn put") && validate_route_handler(&file_contents) {
-			route_handlers.push(RouteHandler::Put(handler))
-		} else if file_contents.contains("async fn patch") && validate_route_handler(&file_contents) {
-			route_handlers.push(RouteHandler::Patch(handler))
-		} else if file_contents.contains("async fn query") && validate_route_handler(&file_contents) {
-			route_handlers.push(RouteHandler::Query(handler))
-		} else if file_contents.contains("async fn mutation") && validate_route_handler(&file_contents) {
-			route_handlers.push(RouteHandler::Mutation(handler))
-		}
-
+		parse_handlers(&mut route_handlers, file_contents, handler);
 	}
 
 	for nested_file_path in route_dirs {
@@ -228,21 +213,7 @@ pub fn routes(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
 			// Check if the contents contain a valid rapid_web route and append them to the route handlers vec
 			// TODO: we should consider supporting HEAD requests here as well (currently, we require that this be done through a traditional .route() call on the route builder function)
-			if file_contents.contains("async fn get") && validate_route_handler(&file_contents) {
-				route_handlers.push(RouteHandler::Get(handler))
-			} else if file_contents.contains("async fn post") && validate_route_handler(&file_contents) {
-				route_handlers.push(RouteHandler::Post(handler))
-			} else if file_contents.contains("async fn delete") && validate_route_handler(&file_contents) {
-				route_handlers.push(RouteHandler::Delete(handler))
-			} else if file_contents.contains("async fn put") && validate_route_handler(&file_contents) {
-				route_handlers.push(RouteHandler::Put(handler))
-			} else if file_contents.contains("async fn patch") && validate_route_handler(&file_contents) {
-				route_handlers.push(RouteHandler::Patch(handler))
-			} else if file_contents.contains("async fn query") && validate_route_handler(&file_contents) {
-				route_handlers.push(RouteHandler::Query(handler))
-			} else if file_contents.contains("async fn mutation") && validate_route_handler(&file_contents) {
-				route_handlers.push(RouteHandler::Mutation(handler))
-			}
+			parse_handlers(&mut route_handlers, file_contents, handler);
 		}
 	}
 
@@ -455,5 +426,24 @@ fn generate_handler_tokens(route_handler: Handler, parsed_path: &str, handler_ty
 			)
 		},
 		_ => quote!(.route(#rapid_routes_path, web::#parsed_handler_type().to(#handler::#parsed_handler_type)#(#middleware_idents)*))
+	}
+}
+
+
+fn parse_handlers(route_handlers: &mut Vec<RouteHandler>, file_contents: String, handler: Handler) {
+	if file_contents.contains("async fn get") && validate_route_handler(&file_contents) {
+		route_handlers.push(RouteHandler::Get(handler))
+	} else if file_contents.contains("async fn post") && validate_route_handler(&file_contents) {
+		route_handlers.push(RouteHandler::Post(handler))
+	} else if file_contents.contains("async fn delete") && validate_route_handler(&file_contents) {
+		route_handlers.push(RouteHandler::Delete(handler))
+	} else if file_contents.contains("async fn put") && validate_route_handler(&file_contents) {
+		route_handlers.push(RouteHandler::Put(handler))
+	} else if file_contents.contains("async fn patch") && validate_route_handler(&file_contents) {
+		route_handlers.push(RouteHandler::Patch(handler))
+	} else if file_contents.contains("async fn query") && validate_route_handler(&file_contents) {
+		route_handlers.push(RouteHandler::Query(handler))
+	} else if file_contents.contains("async fn mutation") && validate_route_handler(&file_contents) {
+		route_handlers.push(RouteHandler::Mutation(handler))
 	}
 }

--- a/crates/rapid-web-codegen/src/lib.rs
+++ b/crates/rapid-web-codegen/src/lib.rs
@@ -427,7 +427,7 @@ fn generate_handler_tokens(route_handler: Handler, parsed_path: &str, handler_ty
 			)
 		},
 		// Currently we still support declaring handlers with a very specific HTTP type (ex: `get` or `post` etc)
-		// ^^^ Eventually, what was described above
+		// ^^^ Eventually, what was described above should get deprecated
 		_ => quote!(.route(#rapid_routes_path, web::#parsed_handler_type().to(#handler::#parsed_handler_type)#(#middleware_idents)*))
 	}
 }

--- a/crates/rapid-web-codegen/src/lib.rs
+++ b/crates/rapid-web-codegen/src/lib.rs
@@ -8,6 +8,7 @@ use std::{
 	io::prelude::*,
 	path::PathBuf,
 };
+use syn::parse_macro_input;
 use utils::{
 	base_file_name, get_all_dirs, get_all_middleware, parse_handler_path, parse_route_path, reverse_route_path, validate_route_handler,
 	REMIX_ROUTE_PATH,
@@ -417,7 +418,7 @@ fn generate_handler_tokens(route_handler: Handler, parsed_path: &str, handler_ty
 			)
 		},
 		"mutation" => {
-			// If we got a mutation type we want to generate routes for each of the following:
+			// If we got a mutation type we want to generate routes for each of the following (all at the same path):
 			// `post`, `put`, `patch`, `delete`
 			quote!(
 				.route(#rapid_routes_path, web::post().to(#handler::#parsed_handler_type)#(#middleware_idents)*)
@@ -432,9 +433,9 @@ fn generate_handler_tokens(route_handler: Handler, parsed_path: &str, handler_ty
 	}
 }
 
-
 /// Function for parsing a route fileer and making sure it contains a valid handler
 /// If it does, we want to push the valid handler to the handlers array
+/// Note: no need to support HEAD and OPTIONS requests
 fn parse_handlers(route_handlers: &mut Vec<RouteHandler>, file_contents: String, handler: Handler) {
 	// TODO: we need to depricate everything except for `query` and `mutation`
 	if file_contents.contains("async fn get") && validate_route_handler(&file_contents) {
@@ -453,3 +454,4 @@ fn parse_handlers(route_handlers: &mut Vec<RouteHandler>, file_contents: String,
 		route_handlers.push(RouteHandler::Mutation(handler))
 	}
 }
+

--- a/crates/rapid-web-codegen/src/lib.rs
+++ b/crates/rapid-web-codegen/src/lib.rs
@@ -407,6 +407,7 @@ fn generate_handler_tokens(route_handler: Handler, parsed_path: &str, handler_ty
 		}
 	};
 
+	// Output our idents based on the handler types
 	match handler_type {
 		// Check if we got a query or mutation..
 		"query" => {
@@ -430,6 +431,7 @@ fn generate_handler_tokens(route_handler: Handler, parsed_path: &str, handler_ty
 		_ => quote!(.route(#rapid_routes_path, web::#parsed_handler_type().to(#handler::#parsed_handler_type)#(#middleware_idents)*))
 	}
 }
+
 
 /// Function for parsing a route fileer and making sure it contains a valid handler
 /// If it does, we want to push the valid handler to the handlers array

--- a/crates/rapid-web-codegen/src/lib.rs
+++ b/crates/rapid-web-codegen/src/lib.rs
@@ -429,7 +429,8 @@ fn generate_handler_tokens(route_handler: Handler, parsed_path: &str, handler_ty
 	}
 }
 
-
+/// Function for parsing a route fileer and making sure it contains a valid handler
+/// If it does, we want to push the valid handler to the handlers array
 fn parse_handlers(route_handlers: &mut Vec<RouteHandler>, file_contents: String, handler: Handler) {
 	if file_contents.contains("async fn get") && validate_route_handler(&file_contents) {
 		route_handlers.push(RouteHandler::Get(handler))

--- a/crates/rapid-web-codegen/src/lib.rs
+++ b/crates/rapid-web-codegen/src/lib.rs
@@ -161,7 +161,12 @@ pub fn routes(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
 			route_handlers.push(RouteHandler::Put(handler))
 		} else if file_contents.contains("async fn patch") && validate_route_handler(&file_contents) {
 			route_handlers.push(RouteHandler::Patch(handler))
+		} else if file_contents.contains("async fn query") && validate_route_handler(&file_contents) {
+			route_handlers.push(RouteHandler::Query(handler))
+		} else if file_contents.contains("async fn mutation") && validate_route_handler(&file_contents) {
+			route_handlers.push(RouteHandler::Mutation(handler))
 		}
+
 	}
 
 	for nested_file_path in route_dirs {
@@ -233,6 +238,10 @@ pub fn routes(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
 				route_handlers.push(RouteHandler::Put(handler))
 			} else if file_contents.contains("async fn patch") && validate_route_handler(&file_contents) {
 				route_handlers.push(RouteHandler::Patch(handler))
+			} else if file_contents.contains("async fn query") && validate_route_handler(&file_contents) {
+				route_handlers.push(RouteHandler::Query(handler))
+			} else if file_contents.contains("async fn mutation") && validate_route_handler(&file_contents) {
+				route_handlers.push(RouteHandler::Mutation(handler))
 			}
 		}
 	}

--- a/crates/rapid-web/Cargo.toml
+++ b/crates/rapid-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapid-web"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 description = "A simple Rust server for the Rapid framework."
 repository = "https://github.com/DarrenBaldwin07/rapid"

--- a/crates/rapid-web/Cargo.toml
+++ b/crates/rapid-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapid-web"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 description = "A simple Rust server for the Rapid framework."
 repository = "https://github.com/DarrenBaldwin07/rapid"
@@ -29,7 +29,7 @@ env_logger = "0.10.0"
 tiny-gradient = "0.1.0"
 serde = "1.0.155"
 lazy_static = "1.4.0"
-rapid-web-codegen = { version = "0.2.1", path = "../rapid-web-codegen" }
+rapid-web-codegen = { version = "0.2.2", path = "../rapid-web-codegen" }
 proc-macro2 = "1.0.53"
 syn = { version = "2.0.10", features = ["full", "extra-traits"] }
 walkdir = "2.3.3"

--- a/crates/rapid-web/examples/rapid_server.rs
+++ b/crates/rapid-web/examples/rapid_server.rs
@@ -3,18 +3,18 @@ use rapid_web::{
 	actix::{web, HttpResponse, HttpServer},
 	server::RapidServer,
 };
-use rapid_web_codegen::main;
+use rapid_web_codegen::{main, rapid_configure, routes};
 
-// TODO: this example is outdated and needs updated
-
-async fn index() -> HttpResponse {
-	HttpResponse::Ok().body("Hey there!")
-}
+// Configure your routes
+//rapid_configure!("src/routes");
 
 #[main]
 async fn main() -> std::io::Result<()> {
 	let app = RapidServer::create(None, None);
 
-	app.listen(HttpServer::new(move || RapidServer::router(None, None).route("/", web::get().to(index))))
-		.await
+
+    app.listen(HttpServer::new(move || {
+
+        RapidServer::router(None, None) // Use the `routes!()` macro with the fs_router...
+    })).await
 }

--- a/crates/rapid-web/src/server.rs
+++ b/crates/rapid-web/src/server.rs
@@ -124,6 +124,8 @@ impl RapidServer {
 	/// * `routes` - A string slice that holds the path to the file system routes root directory (ex: "src/routes") -- this value can be anything as long as it is a valid (relative) directory path
 	/// * `cors` - An optional cors value that can be used to configure the cors middleware
 	/// * `log_type` - An optional logger type that can be used to configure the logger middleware used for every request/response
+	///
+	/// > Docs coming soon...
 	pub fn fs_router(
 		cors: Option<Cors>,
 		log_type: Option<RapidLogger>,

--- a/crates/rapid-web/src/util.rs
+++ b/crates/rapid-web/src/util.rs
@@ -82,7 +82,12 @@ pub fn is_valid_route_function(file_contents: &str) -> bool {
 		return true;
 	} else if file_contents.contains("async fn patch") {
 		return true;
+	} else if file_contents.contains("async fn query") {
+		return true;
+	} else if file_contents.contains("async fn mutation") {
+		return true;
 	}
+
 
 	false
 }


### PR DESCRIPTION
Adds support for `query` and `mutation` handler types 
- No need to specify an exact type (ex: `get` or `post`, etc)
- Did not deprecate the old way of doing things