### PR TITLE
Cv 327 rapid UI dropdown menu bug

### DIFF
--- a/packages/rapid-ui/src/components/overlay/menu/menu/Menu.tsx
+++ b/packages/rapid-ui/src/components/overlay/menu/menu/Menu.tsx
@@ -1,36 +1,36 @@
-import React from "react";
+import React from 'react';
 import {
 	Menu as HeadlessMenu,
 	MenuProps as HeadlessMenuProps,
-} from "@headlessui/react";
-import { RapidStyles } from "../../../../utils";
+} from '@headlessui/react';
+import { RapidStyles } from '../../../../utils';
 
-interface MenuProps extends HeadlessMenuProps<"div"> {
+type MenuProps = {
 	styles?: string;
-}
+} & HeadlessMenuProps<'div'>;
 
-const RAPID_CLASSNAME = "rapid-menu";
+const RAPID_CLASSNAME = 'rapid-menu';
 
 // For now, this is just a complete re-export of the Headless Menu component.
 // At some point we may come back and refactor into our own component -- for now it works as a wrapper so that we can apply themeing
 const Menu = React.forwardRef<HTMLDivElement, MenuProps>(
 	({ styles, ...rest }, ref) => {
-		const defaultStyles = "relative inline-block text-left";
+		const defaultStyles = 'relative inline-block text-left';
 		return (
 			<HeadlessMenu
 				className={RapidStyles(
-					styles || rest.className,
+					styles || (rest.className as string),
 					defaultStyles,
-					RAPID_CLASSNAME
+					RAPID_CLASSNAME,
 				)}
-				as="div"
+				as='div'
 				{...rest}
 				ref={ref}
 			/>
 		);
-	}
+	},
 );
 
-Menu.displayName = "Menu";
+Menu.displayName = 'Menu';
 
 export default Menu;

--- a/packages/rapid-ui/src/components/overlay/menu/menu/Menu.tsx
+++ b/packages/rapid-ui/src/components/overlay/menu/menu/Menu.tsx
@@ -1,39 +1,36 @@
-import React from 'react';
-import { Menu as HeadlessMenu } from '@headlessui/react';
-import { RapidStyles } from '../../../../utils';
+import React from "react";
+import {
+	Menu as HeadlessMenu,
+	MenuProps as HeadlessMenuProps,
+} from "@headlessui/react";
+import { RapidStyles } from "../../../../utils";
 
-interface MenuProps extends React.HTMLAttributes<HTMLDivElement> {
+interface MenuProps extends HeadlessMenuProps<"div"> {
 	styles?: string;
 }
 
-export const HeadlessMenuTyped = Object.assign(HeadlessMenu, {
-	Item: HeadlessMenu.Item,
-	Button: HeadlessMenu.Button,
-	Items: HeadlessMenu.Items,
-});
-
-const RAPID_CLASSNAME = 'rapid-menu';
+const RAPID_CLASSNAME = "rapid-menu";
 
 // For now, this is just a complete re-export of the Headless Menu component.
 // At some point we may come back and refactor into our own component -- for now it works as a wrapper so that we can apply themeing
 const Menu = React.forwardRef<HTMLDivElement, MenuProps>(
 	({ styles, ...rest }, ref) => {
-		const defaultStyles = 'relative inline-block text-left';
+		const defaultStyles = "relative inline-block text-left";
 		return (
 			<HeadlessMenu
 				className={RapidStyles(
 					styles || rest.className,
 					defaultStyles,
-					RAPID_CLASSNAME,
+					RAPID_CLASSNAME
 				)}
-				as='div'
+				as="div"
 				{...rest}
 				ref={ref}
 			/>
 		);
-	},
+	}
 );
 
-Menu.displayName = 'Menu';
+Menu.displayName = "Menu";
 
 export default Menu;

--- a/packages/rapid-ui/src/components/overlay/menu/menuButton/MenuButton.tsx
+++ b/packages/rapid-ui/src/components/overlay/menu/menuButton/MenuButton.tsx
@@ -1,31 +1,33 @@
-import React, { forwardRef } from 'react';
-import { Menu as HeadlessMenu } from '@headlessui/react';
-import { RapidStyles } from '../../../../utils';
-import { createVariant } from '../../../../theme';
+import React, { forwardRef } from "react";
+import {
+	Menu as HeadlessMenu,
+	MenuButtonProps as HeadlessMenuButtonProps,
+} from "@headlessui/react";
+import { RapidStyles } from "../../../../utils";
+import { createVariant } from "../../../../theme";
 
-const THEME_CLASSNAME = 'rapid-menu-button';
+const THEME_CLASSNAME = "rapid-menu-button";
 
 export const menuButtonTheme = createVariant({
 	baseStyle:
-		'p-3 transition-all ease-out duration-300 outline-none inline-flex items-center rounded-xl text-sm font-medium focus:shadow-button-focus focus:outline-none disabled:opacity-50 hover:disabled:cursor-not-allowed',
+		"p-3 transition-all ease-out duration-300 outline-none inline-flex items-center rounded-xl text-sm font-medium focus:shadow-button-focus focus:outline-none disabled:opacity-50 hover:disabled:cursor-not-allowed",
 	variants: {
-		default: 'bg-main hover:bg-hoverMain text-white active:bg-activeMain',
+		default: "bg-main hover:bg-hoverMain text-white active:bg-activeMain",
 		outline:
-			'bg-white hover:bg-hoverWhite border border-lightGrey active:bg-activeWhite',
+			"bg-white hover:bg-hoverWhite border border-lightGrey active:bg-activeWhite",
 	},
 	sizes: {
-		default: 'p-3',
-		sm: 'py-3 px-2',
-		lg: 'px-8 py-3',
+		default: "p-3",
+		sm: "py-3 px-2",
+		lg: "px-8 py-3",
 	},
 	defaultProps: {
-		variant: 'default',
-		size: 'default',
+		variant: "default",
+		size: "default",
 	},
 });
 
-interface MenuButtonProps
-	extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+interface MenuButtonProps extends HeadlessMenuButtonProps<"div"> {
 	styles?: string;
 	variant?: string;
 	size?: string;
@@ -33,14 +35,14 @@ interface MenuButtonProps
 
 const getVariantClassName = (
 	variant: string | undefined,
-	size: string | undefined,
+	size: string | undefined
 ) => {
 	const classNames = [];
 	if (size) classNames.push(`rapid-menu-button-${size}`);
 	if (variant) classNames.push(`rapid-menu-button-${variant}`);
 
 	if (classNames.length > 0) {
-		return classNames.join(' ');
+		return classNames.join(" ");
 	} else {
 		return undefined;
 	}
@@ -54,13 +56,13 @@ const MenuButton = forwardRef<HTMLButtonElement, MenuButtonProps>(
 				{...rest}
 				className={RapidStyles(
 					styles || rest.className,
-					getVariantClassName(variant, size) || THEME_CLASSNAME,
+					getVariantClassName(variant, size) || THEME_CLASSNAME
 				)}
 			/>
 		);
-	},
+	}
 );
 
-MenuButton.displayName = 'MenuButton';
+MenuButton.displayName = "MenuButton";
 
 export default MenuButton;

--- a/packages/rapid-ui/src/components/overlay/menu/menuButton/MenuButton.tsx
+++ b/packages/rapid-ui/src/components/overlay/menu/menuButton/MenuButton.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import React, { forwardRef } from 'react';
 import {
 	Menu as HeadlessMenu,
 	MenuButtonProps as HeadlessMenuButtonProps,

--- a/packages/rapid-ui/src/components/overlay/menu/menuButton/MenuButton.tsx
+++ b/packages/rapid-ui/src/components/overlay/menu/menuButton/MenuButton.tsx
@@ -1,48 +1,48 @@
-import React, { forwardRef } from "react";
+import { forwardRef } from 'react';
 import {
 	Menu as HeadlessMenu,
 	MenuButtonProps as HeadlessMenuButtonProps,
-} from "@headlessui/react";
-import { RapidStyles } from "../../../../utils";
-import { createVariant } from "../../../../theme";
+} from '@headlessui/react';
+import { RapidStyles } from '../../../../utils';
+import { createVariant } from '../../../../theme';
 
-const THEME_CLASSNAME = "rapid-menu-button";
+const THEME_CLASSNAME = 'rapid-menu-button';
 
 export const menuButtonTheme = createVariant({
 	baseStyle:
-		"p-3 transition-all ease-out duration-300 outline-none inline-flex items-center rounded-xl text-sm font-medium focus:shadow-button-focus focus:outline-none disabled:opacity-50 hover:disabled:cursor-not-allowed",
+		'p-3 transition-all ease-out duration-300 outline-none inline-flex items-center rounded-xl text-sm font-medium focus:shadow-button-focus focus:outline-none disabled:opacity-50 hover:disabled:cursor-not-allowed',
 	variants: {
-		default: "bg-main hover:bg-hoverMain text-white active:bg-activeMain",
+		default: 'bg-main hover:bg-hoverMain text-white active:bg-activeMain',
 		outline:
-			"bg-white hover:bg-hoverWhite border border-lightGrey active:bg-activeWhite",
+			'bg-white hover:bg-hoverWhite border border-lightGrey active:bg-activeWhite',
 	},
 	sizes: {
-		default: "p-3",
-		sm: "py-3 px-2",
-		lg: "px-8 py-3",
+		default: 'p-3',
+		sm: 'py-3 px-2',
+		lg: 'px-8 py-3',
 	},
 	defaultProps: {
-		variant: "default",
-		size: "default",
+		variant: 'default',
+		size: 'default',
 	},
 });
 
-interface MenuButtonProps extends HeadlessMenuButtonProps<"div"> {
+type MenuButtonProps = {
 	styles?: string;
 	variant?: string;
 	size?: string;
-}
+} & HeadlessMenuButtonProps<'div'>;
 
 const getVariantClassName = (
 	variant: string | undefined,
-	size: string | undefined
+	size: string | undefined,
 ) => {
 	const classNames = [];
 	if (size) classNames.push(`rapid-menu-button-${size}`);
 	if (variant) classNames.push(`rapid-menu-button-${variant}`);
 
 	if (classNames.length > 0) {
-		return classNames.join(" ");
+		return classNames.join(' ');
 	} else {
 		return undefined;
 	}
@@ -55,14 +55,14 @@ const MenuButton = forwardRef<HTMLButtonElement, MenuButtonProps>(
 				ref={ref}
 				{...rest}
 				className={RapidStyles(
-					styles || rest.className,
-					getVariantClassName(variant, size) || THEME_CLASSNAME
+					styles || (rest.className as string),
+					getVariantClassName(variant, size) || THEME_CLASSNAME,
 				)}
 			/>
 		);
-	}
+	},
 );
 
-MenuButton.displayName = "MenuButton";
+MenuButton.displayName = 'MenuButton';
 
 export default MenuButton;

--- a/packages/rapid-ui/src/components/overlay/menu/menuItem/MenuItem.tsx
+++ b/packages/rapid-ui/src/components/overlay/menu/menuItem/MenuItem.tsx
@@ -1,33 +1,32 @@
-import { Menu as HeadlessMenu } from '@headlessui/react';
-import { HeadlessMenuTyped } from '../menu/Menu';
-import { RapidStyles } from '../../../../utils';
-import type { ExtractProps } from '../../../../types';
+import {
+	Menu as HeadlessMenu,
+	MenuItemProps as HeadlessMenuItemProps,
+} from "@headlessui/react";
+import { RapidStyles } from "../../../../utils";
 
-const RAPID_CLASSNAME = 'rapid-menu-item';
-
-type MenuItemType = ExtractProps<typeof HeadlessMenuTyped.Item>;
+const RAPID_CLASSNAME = "rapid-menu-item";
 
 // TODO: fix this
 // @ts-ignore
-interface MenuItemProps extends MenuItemType {
+interface MenuItemProps extends HeadlessMenuItemProps<"div"> {
 	styles?: string;
 }
 
 const MenuItem = ({ styles, ...rest }: MenuItemProps) => {
 	const defaultStyles =
-		'p-1 hover:disabled:cursor-not-allowed hover:cursor-pointer';
+		"p-1 hover:disabled:cursor-not-allowed hover:cursor-pointer";
 	return (
 		<HeadlessMenu.Item
 			className={RapidStyles(
 				styles || rest.className,
 				defaultStyles,
-				RAPID_CLASSNAME,
+				RAPID_CLASSNAME
 			)}
 			{...rest}
 		/>
 	);
 };
 
-MenuItem.displayName = 'MenuItem';
+MenuItem.displayName = "MenuItem";
 
 export default MenuItem;

--- a/packages/rapid-ui/src/components/overlay/menu/menuItem/MenuItem.tsx
+++ b/packages/rapid-ui/src/components/overlay/menu/menuItem/MenuItem.tsx
@@ -1,32 +1,32 @@
 import {
 	Menu as HeadlessMenu,
 	MenuItemProps as HeadlessMenuItemProps,
-} from "@headlessui/react";
-import { RapidStyles } from "../../../../utils";
+} from '@headlessui/react';
+import { RapidStyles } from '../../../../utils';
 
-const RAPID_CLASSNAME = "rapid-menu-item";
+const RAPID_CLASSNAME = 'rapid-menu-item';
 
 // TODO: fix this
 // @ts-ignore
-interface MenuItemProps extends HeadlessMenuItemProps<"div"> {
+type MenuItemProps = {
 	styles?: string;
-}
+} & HeadlessMenuItemProps<'div'>;
 
 const MenuItem = ({ styles, ...rest }: MenuItemProps) => {
 	const defaultStyles =
-		"p-1 hover:disabled:cursor-not-allowed hover:cursor-pointer";
+		'p-1 hover:disabled:cursor-not-allowed hover:cursor-pointer';
 	return (
 		<HeadlessMenu.Item
 			className={RapidStyles(
-				styles || rest.className,
+				styles || (rest.className as string),
 				defaultStyles,
-				RAPID_CLASSNAME
+				RAPID_CLASSNAME,
 			)}
 			{...rest}
 		/>
 	);
 };
 
-MenuItem.displayName = "MenuItem";
+MenuItem.displayName = 'MenuItem';
 
 export default MenuItem;

--- a/packages/rapid-ui/src/components/overlay/menu/menuItems/MenuItems.tsx
+++ b/packages/rapid-ui/src/components/overlay/menu/menuItems/MenuItems.tsx
@@ -1,11 +1,15 @@
-import { Menu as HeadlessMenu, Transition } from '@headlessui/react';
-import React, { Fragment } from 'react';
-import { RapidStyles } from '../../../../utils';
-import { ScaleFade } from '../../../transition';
+import {
+	Menu as HeadlessMenu,
+	MenuItemsProps as HeadlessMenuItemsProps,
+	Transition,
+} from "@headlessui/react";
+import React, { Fragment } from "react";
+import { RapidStyles } from "../../../../utils";
+import { ScaleFade } from "../../../transition";
 
-const RAPID_CLASSNAME = 'rapid-menu-items';
+const RAPID_CLASSNAME = "rapid-menu-items";
 
-interface MenuItemsProps extends React.HTMLAttributes<HTMLDivElement> {
+interface MenuItemsProps extends HeadlessMenuItemsProps<"div"> {
 	styles?: string;
 	wrapperStyles?: string;
 }
@@ -16,26 +20,23 @@ const MenuItems = React.forwardRef<
 >(({ styles, children, wrapperStyles, ...rest }, ref) => {
 	// Simple default styles for the menu items
 	const defaultStyles =
-		'bg-white border border-lightGrey mt-2 rounded-lg shadow-lg absolute z-10 flex flex-col space-y-2 py-1 w-56';
+		"bg-white border border-lightGrey mt-2 rounded-lg shadow-lg absolute z-10 flex flex-col space-y-2 py-1 w-56";
 
 	return (
 		<Transition
 			as={Fragment}
-			leave='transition ease-in duration-100'
-			leaveFrom='opacity-100 scale-100'
-			leaveTo='opacity-0 scale-95'
+			leave="transition ease-in duration-100"
+			leaveFrom="opacity-100 scale-100"
+			leaveTo="opacity-0 scale-95"
 		>
 			<HeadlessMenu.Items
 				{...rest}
-				className={RapidStyles(wrapperStyles, '', RAPID_CLASSNAME)}
+				className={RapidStyles(wrapperStyles, "", RAPID_CLASSNAME)}
 				ref={ref}
 			>
 				<ScaleFade
-					styles={RapidStyles(
-						styles || rest.className,
-						defaultStyles,
-					)}
-					exitAnimation='exit'
+					styles={RapidStyles(styles || rest.className, defaultStyles)}
+					exitAnimation="exit"
 				>
 					{children}
 				</ScaleFade>
@@ -44,6 +45,6 @@ const MenuItems = React.forwardRef<
 	);
 });
 
-MenuItems.displayName = 'MenuItems';
+MenuItems.displayName = "MenuItems";
 
 export default MenuItems;

--- a/packages/rapid-ui/src/components/overlay/menu/menuItems/MenuItems.tsx
+++ b/packages/rapid-ui/src/components/overlay/menu/menuItems/MenuItems.tsx
@@ -2,17 +2,18 @@ import {
 	Menu as HeadlessMenu,
 	MenuItemsProps as HeadlessMenuItemsProps,
 	Transition,
-} from "@headlessui/react";
-import React, { Fragment } from "react";
-import { RapidStyles } from "../../../../utils";
-import { ScaleFade } from "../../../transition";
+} from '@headlessui/react';
+import React, { Fragment } from 'react';
+import { RapidStyles } from '../../../../utils';
+import { ScaleFade } from '../../../transition';
 
-const RAPID_CLASSNAME = "rapid-menu-items";
+const RAPID_CLASSNAME = 'rapid-menu-items';
 
-interface MenuItemsProps extends HeadlessMenuItemsProps<"div"> {
+type MenuItemsProps = {
 	styles?: string;
 	wrapperStyles?: string;
-}
+	children?: React.ReactNode;
+} & HeadlessMenuItemsProps<'div'>;
 
 const MenuItems = React.forwardRef<
 	React.ElementRef<typeof HeadlessMenu.Items>,
@@ -20,23 +21,26 @@ const MenuItems = React.forwardRef<
 >(({ styles, children, wrapperStyles, ...rest }, ref) => {
 	// Simple default styles for the menu items
 	const defaultStyles =
-		"bg-white border border-lightGrey mt-2 rounded-lg shadow-lg absolute z-10 flex flex-col space-y-2 py-1 w-56";
+		'bg-white border border-lightGrey mt-2 rounded-lg shadow-lg absolute z-10 flex flex-col space-y-2 py-1 w-56';
 
 	return (
 		<Transition
 			as={Fragment}
-			leave="transition ease-in duration-100"
-			leaveFrom="opacity-100 scale-100"
-			leaveTo="opacity-0 scale-95"
+			leave='transition ease-in duration-100'
+			leaveFrom='opacity-100 scale-100'
+			leaveTo='opacity-0 scale-95'
 		>
 			<HeadlessMenu.Items
 				{...rest}
-				className={RapidStyles(wrapperStyles, "", RAPID_CLASSNAME)}
+				className={RapidStyles(wrapperStyles, '', RAPID_CLASSNAME)}
 				ref={ref}
 			>
 				<ScaleFade
-					styles={RapidStyles(styles || rest.className, defaultStyles)}
-					exitAnimation="exit"
+					styles={RapidStyles(
+						styles || (rest.className as string),
+						defaultStyles,
+					)}
+					exitAnimation='exit'
 				>
 					{children}
 				</ScaleFade>
@@ -45,6 +49,6 @@ const MenuItems = React.forwardRef<
 	);
 });
 
-MenuItems.displayName = "MenuItems";
+MenuItems.displayName = 'MenuItems';
 
 export default MenuItems;


### PR DESCRIPTION
Fixed the type bug in [this ticket](https://linear.app/cincinnati-ventures/issue/CV-327/rapid-ui-dropdown-menu-bug)

HeadlessUI started exporting their component props in [this PR](https://github.com/tailwindlabs/headlessui/pull/2282).

Imported their props as HeadlessXXProps. 
Converted our MenuProps interface into an intersection type of their props and the ones we add, the interface led to errors. 