### PR TITLE
refactor: improve cli and terminal experience

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,12 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "memchr"
@@ -1474,6 +1471,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "pretty_env_logger"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
+dependencies = [
+ "env_logger",
+ "log",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,6 +1560,8 @@ dependencies = [
  "colorful",
  "ctrlc",
  "include_dir",
+ "log",
+ "pretty_env_logger",
  "requestty",
  "rust-embed",
  "serde",
@@ -1586,10 +1595,10 @@ dependencies = [
  "actix-web-httpauth",
  "clerk-rs",
  "colorful",
- "env_logger",
  "futures-util",
  "lazy_static",
  "log",
+ "pretty_env_logger",
  "proc-macro2",
  "rapid-cli",
  "rapid-web-codegen",

--- a/crates/rapid-cli/Cargo.toml
+++ b/crates/rapid-cli/Cargo.toml
@@ -23,6 +23,8 @@ clap = { version = "4.1.4", features = ["derive", "cargo"] }
 colorful = "0.2.2"
 ctrlc = "3.2.5"
 include_dir = "0.7.3"
+log = "0.4.19"
+pretty_env_logger = "0.5.0"
 requestty = "0.5.0"
 rust-embed = "6.4.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/rapid-cli/src/bin/main.rs
+++ b/crates/rapid-cli/src/bin/main.rs
@@ -1,5 +1,7 @@
 use rapid_cli::cli::{CliError, Config, RapidCLI};
 fn main() -> Result<(), CliError<'static>> {
+	pretty_env_logger::formatted_builder().filter_level(log::LevelFilter::Info).init();
+
 	// TODO: eventually, the user will be able to persist settings via a global config file
 	// and all those settings will be loaded in and passed to this object (ex: rapid configure or rapid auth)
 	let app = RapidCLI::new(Config {});

--- a/crates/rapid-cli/src/commands/init.rs
+++ b/crates/rapid-cli/src/commands/init.rs
@@ -2,15 +2,15 @@ use super::RapidCommand;
 use crate::{
 	cli::{current_directory, Config},
 	constants::BOLT_EMOJI,
-	tui::{logo, rapid_logo},
+	tui::logo,
 };
 use clap::{arg, value_parser, ArgAction, ArgMatches, Command};
 use colorful::{Color, Colorful};
 use rust_embed::RustEmbed;
+use log::{error, info};
 use std::{
 	fs::{write, File},
 	path::PathBuf,
-	thread, time,
 };
 
 #[derive(RustEmbed)]
@@ -104,14 +104,14 @@ pub fn ui_subcommand_handler(init_args: [&str; 3], subcommand_args: &ArgMatches,
 							break;
 						}
 						_ => {
-							println!("{}", "No template found. Please try '--vite' or '--remix'".color(Color::Red));
+							error!("{}", "no template found. Please try '--vite' or '--remix'".color(Color::Red));
 							break;
 						}
 					}
 				}
 			}
 			None => {
-				println!("{}", "No template found. Please try '--vite' or '--remix'".color(Color::Red));
+				error!("{}", "no template found. Please try '--vite' or '--remix'".color(Color::Red));
 			}
 		}
 	}
@@ -128,19 +128,19 @@ pub fn server_subcommand_handler(init_args: [&str; 1], subcommand_args: &ArgMatc
 							return;
 						}
 						_ => {
-							println!("{}", "No command found. Please try '--deploy'".color(Color::Red));
+							error!("{}", "no command found. Please try '--deploy'".color(Color::Red));
 							return;
 						}
 					}
 				}
 			}
 			None => {
-				println!("{}", "No command found. Please try '--deploy'".color(Color::Red));
+				error!("{}", "no command found. Please try '--deploy'".color(Color::Red));
 			}
 		}
 	}
 
-	println!("{}", "No init commands found! Please try using '--deploy'".color(Color::Red));
+	error!("{}", "no init commands found! Please try using '--deploy'".color(Color::Red));
 }
 
 fn parse_init_args(args: &ArgMatches) {
@@ -164,11 +164,11 @@ fn parse_init_args(args: &ArgMatches) {
 					}
 					"fullstack" => {
 						// TODO: this will be the command that runs for initializing a new rapid app inside of an existing nextjs or remix application (different from rapid new that scaffolds an entire fullstack app with rapid)
-						println!("Coming soon...");
+						error!("coming soon...");
 						return;
 					}
 					_ => {
-						println!("{} {}", "No init scripts found.".color(Color::Red), arg);
+						error!("no init scripts found for `{}`", arg);
 						break;
 					}
 				}
@@ -177,11 +177,11 @@ fn parse_init_args(args: &ArgMatches) {
 		}
 	}
 
-	println!("{}", "No init scripts found!".color(Color::Red));
+	error!("no init scripts found");
 }
 
 pub fn init_vite_template(current_working_directory: PathBuf, arg: &str) {
-	println!("{} {:?}...", "Initializing rapid-ui with the template".color(Color::Green), arg);
+	info!("Initializing rapid-ui with the template: {:?}...", arg);
 	let tailwind_config_contents = Asset::get("tailwind.config.js").unwrap();
 	let postcss_config_contents = Asset::get("postcss.config.js").unwrap();
 	let index_css_contents = Asset::get("index.css").unwrap();
@@ -195,21 +195,14 @@ pub fn init_vite_template(current_working_directory: PathBuf, arg: &str) {
 	write("postcss.config.js", std::str::from_utf8(postcss_config_contents.data.as_ref()).unwrap()).expect("Could not write to postcss config file!");
 	write("src/index.css", std::str::from_utf8(index_css_contents.data.as_ref()).unwrap()).expect("Could not write to index.css file!");
 
-	// Sleep a little to show loading animation, etc (there is a nice one we could use from the "tui" crate)
-	let timeout = time::Duration::from_millis(500);
-	thread::sleep(timeout);
-
-	println!(
-		"{} {} {} {}",
-		format!("{}", rapid_logo()).bold(),
-		"Success".bg_blue().color(Color::White).bold(),
+	info!(
+		"{} rapid-ui has been initialized in your Vite project!",
 		BOLT_EMOJI,
-		"Rapid-ui has been initialized in your Vite project!"
 	);
 }
 
 pub fn init_remix_template(current_working_directory: PathBuf, arg: &str) {
-	println!("{} {:?}...", "Initializing rapid-ui with the template".color(Color::Green), arg);
+	info!("initializing rapid-ui with the template {:?}...", arg);
 	let tailwind_config_contents = RemixAssets::get("tailwind.config.ts").unwrap();
 	let index_css_contents = RemixAssets::get("index.css").unwrap();
 	// Make the two config files that we need
@@ -220,21 +213,14 @@ pub fn init_remix_template(current_working_directory: PathBuf, arg: &str) {
 		.expect("Could not write to tailwind config file!");
 	write("app/index.css", std::str::from_utf8(index_css_contents.data.as_ref()).unwrap()).expect("Could not write to index.css file!");
 
-	// Sleep a little to show loading animation, etc (there is a nice one we could use from the "tui" crate)
-	let timeout = time::Duration::from_millis(500);
-	thread::sleep(timeout);
-
-	println!(
-		"{} {} {} {}",
-		format!("{}", rapid_logo()).bold(),
-		"Success".bg_blue().color(Color::White).bold(),
+	info!(
+		"{} rapid-ui has been initialized in your Remix project!",
 		BOLT_EMOJI,
-		"Rapid-ui has been initialized in your Remix project!"
 	);
 }
 
 pub fn init_nextjs_template(current_working_directory: PathBuf, arg: &str) {
-	println!("{} {:?}...", "Initializing rapid-ui with the template".color(Color::Green), arg);
+	info!("initializing rapid-ui with the template {:?}...", arg);
 	let tailwind_config_contents = NextJsAssets::get("tailwind.config.ts").unwrap();
 	let postcss_config_contents = NextJsAssets::get("postcss.config.js").unwrap();
 
@@ -246,21 +232,14 @@ pub fn init_nextjs_template(current_working_directory: PathBuf, arg: &str) {
 	write("tailwind.config.ts", std::str::from_utf8(tailwind_config_contents.data.as_ref()).unwrap())
 		.expect("Could not write to tailwind config file!");
 
-	// Sleep a little to show loading animation, etc (there is a nice one we could use from the "tui" crate)
-	let timeout = time::Duration::from_millis(500);
-	thread::sleep(timeout);
-
-	println!(
-		"{} {} {} {}",
-		format!("{}", rapid_logo()).bold(),
-		"Success".bg_blue().color(Color::White).bold(),
+	info!(
+		"{} rapid-ui has been initialized in your NextJS project!",
 		BOLT_EMOJI,
-		"Rapid-ui has been initialized in your NextJS project!"
 	);
 }
 
 pub fn init_deployments_dockerfile(current_working_directory: PathBuf) {
-	println!("{}...", "Initializing rapid deployments".color(Color::Green));
+	info!("Initializing rapid deployments...");
 	let dockerfile_conents = Dockerfiles::get("rapidServer.Dockerfile").unwrap();
 
 	// Create the Dockerfile
@@ -270,24 +249,12 @@ pub fn init_deployments_dockerfile(current_working_directory: PathBuf) {
 	// Write to the Dockerfuke
 	write("rapid.Dockerfile", std::str::from_utf8(dockerfile_conents.data.as_ref()).unwrap()).expect("Could not write to postcss config file!");
 
-	// Sleep a little to show loading animation, etc (there is a nice one we could use from the "tui" crate)
-	let timeout = time::Duration::from_millis(500);
-	thread::sleep(timeout);
-
-	println!(
-		"{} {} {} {} {}",
-		"\n\n🚀".bold(),
-		"Next Steps".bg_blue().color(Color::White).bold(),
+	info!(
+		"{}\n{}{}\n{}{}",
 		BOLT_EMOJI,
-		format!(
-			"{}{}",
-			format!("\n\nBuild: {}", "").bold(),
-			"docker build -t rapid-server -f ./rapid.Dockerfile .".color(Color::LightCyan)
-		),
-		format!(
-			"{}{}",
-			format!("\nRun: {}", "").bold(),
-			"docker run -p 8080:8080 rapid-server".color(Color::LightCyan)
-		),
+		"Build: ".bold(),
+		"docker build -t rapid-server -f ./rapid.Dockerfile .".color(Color::LightCyan),
+		"Run: ".bold(),
+		"docker run -p 8080:8080 rapid-server".color(Color::LightCyan),
 	);
 }

--- a/crates/rapid-cli/src/commands/new.rs
+++ b/crates/rapid-cli/src/commands/new.rs
@@ -2,11 +2,12 @@ use super::RapidCommand;
 use crate::{
 	cli::{current_directory, Config},
 	constants::BOLT_EMOJI,
-	tui::{clean_console, indent, logo, rapid_logo},
+	tui::{indent, logo, rapid_logo},
 };
-use clap::{arg, Arg, ArgAction, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use colorful::{Color, Colorful};
 use include_dir::{include_dir, Dir};
+use log::error;
 use requestty::{prompt, prompt_one, Answer, Question};
 use spinach::Spinach;
 use std::{
@@ -107,7 +108,7 @@ pub fn init_remix_template(current_working_directory: PathBuf) {
 
 	// Validate that the project name does not contain any invalid chars
 	if !project_name.chars().all(|x| x.is_alphanumeric() || x == '-' || x == '_') {
-		println!("Aborting...your project name may only contain alphanumeric characters along with '-' and '_'...");
+		error!("Aborting...your project name may only contain alphanumeric characters along with '-' and '_'...");
 		exit(64);
 	}
 
@@ -149,11 +150,8 @@ pub fn init_remix_template(current_working_directory: PathBuf) {
 	let package_manager = match package_manager.get("packageManagerSelect") {
 		Some(Answer::ListItem(choice)) => choice.text.clone(),
 		_ => {
-			println!(
-				"{}",
+			error!(
 				"Aborting...an error occurred while trying to parse package manager selection. Please try again!"
-					.bold()
-					.color(Color::Red)
 			);
 			exit(64);
 		}
@@ -173,11 +171,9 @@ pub fn init_remix_template(current_working_directory: PathBuf) {
 	let tech_choices = match tech_choices {
 		Answer::ListItems(choices) => choices,
 		_ => {
-			println!(
+			error!(
 				"{}",
-				"Aborting...an error occurred while trying to parse technology choices. Please try again!"
-					.bold()
-					.color(Color::Red)
+				"aborting...an error occurred while trying to parse technology choices. Please try again!"
 			);
 			exit(64);
 		}
@@ -249,8 +245,6 @@ pub fn init_remix_template(current_working_directory: PathBuf) {
 
 	loading.succeed("Installed dependencies!");
 
-	clean_console();
-
 	println!(
 		"\n\n{} {} {} {}",
 		format!("{}", rapid_logo()).bold(),
@@ -283,7 +277,7 @@ pub fn init_server_template(current_working_directory: PathBuf, _: &str) {
 
 	// Validate that the project name does not contain any invalid chars
 	if !project_name.chars().all(|x| x.is_alphanumeric() || x == '-' || x == '_') {
-		println!("Aborting...your project name may only contain alphanumeric characters along with '-' and '_'...");
+		error!("aborting...your project name may only contain alphanumeric characters along with '-' and '_'...");
 		exit(64);
 	}
 
@@ -345,8 +339,6 @@ pub fn init_server_template(current_working_directory: PathBuf, _: &str) {
 	// Stop our loading spinner
 	loading.stop();
 
-	clean_console();
-
 	println!(
 		"\n\n{} {} {} {}",
 		format!("{}", rapid_logo()).bold(),
@@ -380,7 +372,7 @@ pub fn init_nextjs_template(current_working_directory: PathBuf) {
 
 	// Validate that the project name does not contain any invalid chars
 	if !project_name.chars().all(|x| x.is_alphanumeric() || x == '-' || x == '_') {
-		println!("Aborting...your project name may only contain alphanumeric characters along with '-' and '_'...");
+		error!("aborting...your project name may only contain alphanumeric characters along with '-' and '_'...");
 		exit(64);
 	}
 
@@ -489,8 +481,6 @@ pub fn init_nextjs_template(current_working_directory: PathBuf) {
 		.expect("Error: Could not install project dependencies!");
 
 	loading.succeed("Installed dependencies!");
-
-	clean_console();
 
 	println!(
 		"\n\n{} {} {} {}",

--- a/crates/rapid-cli/src/commands/run.rs
+++ b/crates/rapid-cli/src/commands/run.rs
@@ -2,11 +2,12 @@ use super::RapidCommand;
 use crate::{
 	cli::{current_directory, Config},
 	rapid_config::config::{find_rapid_config, is_rapid, AppType, RapidConfig},
-	tui::{logo, rapid_logo},
+	tui::logo,
 };
 use clap::{arg, value_parser, ArgAction, ArgMatches, Command};
 use spinach::Spinach;
 use std::{path::PathBuf, process::Command as StdCommand, str::FromStr};
+use log::info;
 pub struct Run {}
 
 impl RapidCommand for Run {
@@ -175,7 +176,7 @@ fn handle_run_server(server_port: u16, app_type: String) {
 		s.succeed("Rapid build scripts installed!");
 	}
 
-	println!("{} Building rapid application...", rapid_logo());
+	info!("building rapid application...");
 
 	// Trigger the shell command to actually run + watch the rapid server
 	StdCommand::new("sh")

--- a/crates/rapid-cli/src/commands/templates.rs
+++ b/crates/rapid-cli/src/commands/templates.rs
@@ -10,7 +10,7 @@ impl RapidCommand for Templates {
 		Command::new("templates").about("SaaS templates for the rapid framework.")
 	}
 
-	fn execute(_: &Config, args: &ArgMatches) -> Result<(), crate::cli::CliError<'static>> {
+	fn execute(_: &Config, _args: &ArgMatches) -> Result<(), crate::cli::CliError<'static>> {
 		println!("{}", logo());
 		println!("> Welcome to RAPID templates");
 		Ok(())

--- a/crates/rapid-cli/src/tui.rs
+++ b/crates/rapid-cli/src/tui.rs
@@ -17,11 +17,14 @@ pub fn indent(amount: u32) -> String {
 }
 
 /// Logo with signs
-pub fn rapid_logo<'a>() -> GradientDisplay<'a, [RGB; 4]> {
-	GradientStr::gradient(
-		&">>> R A P I D",
-		[RGB::new(9, 42, 208), RGB::new(26, 78, 96), RGB::new(9, 42, 208), RGB::new(14, 197, 255)],
-	)
+pub fn rapid_logo<'a>() -> &'static str {
+	// GradientStr::gradient(
+	// 	&">>> R A P I D",
+	// 	[RGB::new(9, 42, 208), RGB::new(26, 78, 96), RGB::new(9, 42, 208), RGB::new(14, 197, 255)],
+	// )
+	// precomputed string of above gradient
+	// this allows the use in Spinach spinners
+	"\x1b[38;2;9;42;208m>\x1b[0m\x1b[38;2;15;55;175m>\x1b[0m\x1b[38;2;20;65;140m>\x1b[0m\x1b[38;2;26;78;96m \x1b[0m\x1b[38;2;21;68;130mR\x1b[0m\x1b[38;2;17;60;158m \x1b[0m\x1b[38;2;14;52;184mA\x1b[0m\x1b[38;2;9;42;208m \x1b[0m\x1b[38;2;9;99;215mP\x1b[0m\x1b[38;2;10;130;223m \x1b[0m\x1b[38;2;11;155;233mI\x1b[0m\x1b[38;2;12;177;244m \x1b[0m\x1b[38;2;14;197;255mD\x1b[0m"
 }
 
 /// Normal Logo

--- a/crates/rapid-web/Cargo.toml
+++ b/crates/rapid-web/Cargo.toml
@@ -25,7 +25,7 @@ rapid-cli = { version = "0.5.7", path = "../rapid-cli" }
 futures-util = "0.3.26"
 colorful = "0.2.2"
 log = "0.4.17"
-env_logger = "0.10.0"
+pretty_env_logger = "0.5.0"
 tiny-gradient = "0.1.0"
 serde = "1.0.155"
 lazy_static = "1.4.0"
@@ -36,5 +36,3 @@ walkdir = "2.3.3"
 regex = "1.7.3"
 spinach = "2.1.0"
 clerk-rs = "0.1.7"
-
-

--- a/crates/rapid-web/src/logger.rs
+++ b/crates/rapid-web/src/logger.rs
@@ -23,9 +23,8 @@ pub fn init_logger() {
 /// 3. `RapidLogger::verbose`
 ///
 /// # Example output
-/// [rapid-web::logger] REQUEST GET /get-todos HTTP/1.1
-///
-///
+/// INFO  rapid_web::logger > REQUEST GET /hello HTTP/1.1
+/// INFO  rapid_web::logger > RESPONSE 200 OK
 #[derive(Copy, Clone)]
 pub enum LoggerType {
 	Minimal,
@@ -47,9 +46,8 @@ pub struct RapidLogger {
 /// 3. `RapidLogger::verbose`
 ///
 /// # Example output
-/// [rapid-web::logger] REQUEST GET /get-todos HTTP/1.1
-///
-///
+/// INFO  rapid_web::logger > REQUEST GET /hello HTTP/1.1
+/// INFO  rapid_web::logger > RESPONSE 200 OK
 impl RapidLogger {
 	pub fn minimal() -> Self {
 		Self {

--- a/crates/rapid-web/src/server.rs
+++ b/crates/rapid-web/src/server.rs
@@ -6,9 +6,9 @@ use super::{
 	},
 	cors::Cors,
 	default_routes::static_files,
-	logger::{init_logger, RapidLogger},
+	logger::RapidLogger,
 	shift::generate::create_typescript_types,
-	tui::{clean_console, server_init},
+	tui::server_init,
 	util::{
 		check_for_invalid_handlers, get_bindings_directory, get_routes_dir, get_server_port, should_generate_types, NEXTJS_ROUTE_PATH,
 		REMIX_ROUTE_PATH,
@@ -20,12 +20,10 @@ use actix_http::{body::MessageBody, Request, Response};
 use actix_service::{IntoServiceFactory, ServiceFactory};
 use actix_web::dev::AppConfig;
 use lazy_static::lazy_static;
-use rapid_cli::{
-	rapid_config::config::{find_rapid_config, RapidConfig},
-	tui::rapid_logo,
-};
-use spinach::Spinach;
-use std::{env::current_dir, path::PathBuf, thread, time};
+use rapid_cli::rapid_config::config::{find_rapid_config, RapidConfig};
+use std::{env::current_dir, path::PathBuf, time::Instant};
+use log::info;
+use crate::logger::init_logger;
 extern crate proc_macro;
 
 #[derive(Clone)]
@@ -188,9 +186,6 @@ fn get_default_bind_config(config: RapidConfig, host_name: Option<String>, port:
 }
 
 pub fn generate_typescript_types(bindings_out_dir: PathBuf, routes_dir: String, config: RapidConfig) {
-	// Clean the console before proceeding...
-	clean_console();
-
 	// Check if we should be converting types inside of every directory
 	let every_dir_types_gen = match config.app_type.as_str() {
 		"server" => match config.server {
@@ -230,16 +225,11 @@ pub fn generate_typescript_types(bindings_out_dir: PathBuf, routes_dir: String, 
 		routes_directory.clone()
 	};
 
-	// Show a loading spinner as needed
-	let loading = Spinach::new(format!("{} Generating types...", rapid_logo()));
+	let start_time = Instant::now();
+	info!("generating types...");
 
 	// TODO: Support output types with this function
 	create_typescript_types(bindings_out_dir, routes_directory, type_generation_directory);
 
-	// Sleep a little to show loading animation
-	let timeout = time::Duration::from_millis(650);
-	thread::sleep(timeout);
-
-	// Stop the loading animation
-	loading.stop();
+	info!("generated types in {} ms", start_time.elapsed().as_millis());
 }

--- a/crates/rapid-web/src/server.rs
+++ b/crates/rapid-web/src/server.rs
@@ -114,6 +114,11 @@ impl RapidServer {
 	}
 
 	/// Takes in a pre-configured HttpServer and listens on the specified port(s)
+	/// 
+	/// # Notes
+	/// This function will try to initalize a logger in case one has not already been initalized.
+	/// If you would like to use your own logger, make sure it has been initalized before this 
+	/// function is called
 	pub async fn listen<F, I, S, B>(self, server: HttpServer<F, I, S, B>) -> std::io::Result<()>
 	where
 		F: Fn() -> I + Send + Clone + 'static,

--- a/crates/rapid-web/src/server.rs
+++ b/crates/rapid-web/src/server.rs
@@ -20,9 +20,10 @@ use actix_http::{body::MessageBody, Request, Response};
 use actix_service::{IntoServiceFactory, ServiceFactory};
 use actix_web::dev::AppConfig;
 use lazy_static::lazy_static;
+use spinach::Spinach;
 use rapid_cli::rapid_config::config::{find_rapid_config, RapidConfig};
+use rapid_cli::tui::rapid_logo;
 use std::{env::current_dir, path::PathBuf, time::Instant};
-use log::info;
 use crate::logger::init_logger;
 extern crate proc_macro;
 
@@ -231,10 +232,9 @@ pub fn generate_typescript_types(bindings_out_dir: PathBuf, routes_dir: String, 
 	};
 
 	let start_time = Instant::now();
-	info!("generating types...");
-
+	let loading = Spinach::new(format!("{} generating types...", rapid_logo()));
 	// TODO: Support output types with this function
 	create_typescript_types(bindings_out_dir, routes_directory, type_generation_directory);
-
-	info!("generated types in {} ms", start_time.elapsed().as_millis());
+	
+	loading.stop_with(rapid_logo(), format!("generated types in {} ms", start_time.elapsed().as_millis()), None);
 }

--- a/crates/rapid-web/src/shift/convert.rs
+++ b/crates/rapid-web/src/shift/convert.rs
@@ -2,6 +2,7 @@ use super::util::{get_struct_generics, indent, space};
 use std::{env::current_dir, ffi::OsStr, fs::File, io::prelude::*};
 use syn::{parse_file, Item, ItemStruct, ItemType, Type};
 use walkdir::WalkDir;
+use log::error;
 
 #[derive(Debug, Clone)]
 pub struct TypescriptType {
@@ -217,6 +218,7 @@ pub fn get_rust_typename(rust_type: &Type) -> String {
 }
 
 // TODO: support `Function`, `TypeAlias`, `Enum`, and `Const`
+#[allow(dead_code)]
 pub enum ConversionType {
 	Primitive,
 	Struct,
@@ -304,12 +306,15 @@ impl TypescriptConverter {
 	}
 
 	// TODO: we should also convert constants to typescript aliases as well
+	#[allow(dead_code)]
 	pub fn convert_const() {}
 
 	// TODO: enums in typescript suck but might be ideal to atleast support conversion
+	#[allow(dead_code)]
 	pub fn convert_enum() {}
 
 	// TODO: support converting all functions to typescript types
+	#[allow(dead_code)]
 	pub fn convert_function() {}
 
 	/// Converts rust type aliases to typescript types or interfaces
@@ -417,7 +422,7 @@ pub fn convert_all_types_in_path(directory: &str, converter_instance: &mut Types
 			}
 			Err(_) => {
 				// if we were not able to parse the file lets error out
-				println!("An error occurred when attempting to parse directory with path: {:?}", parsing_directory);
+				error!("An error occurred when attempting to parse directory with path: {:?}", parsing_directory);
 				continue;
 			}
 		}

--- a/crates/rapid-web/src/tui.rs
+++ b/crates/rapid-web/src/tui.rs
@@ -1,40 +1,14 @@
 use colorful::{Color, Colorful};
-use rapid_cli::tui::rapid_logo;
 use std::env;
-use tiny_gradient::{GradientDisplay, GradientStr, RGB};
-
-pub fn started_server_message() -> colorful::core::color_string::CString {
-	"Started".bg_blue().color(Color::White).bold()
-}
+use log::info;
 
 pub fn server_init(bind_config: (String, u16)) {
-	// This print statement removes all prev terminal logs (aka the same as running a clear command)
-	print!("{esc}c", esc = 27 as char);
 	let server_url = format!("http://{}:{}", &bind_config.0, &bind_config.1).color(Color::Blue);
 	// Grab the current crate version at compile time...
 	let crate_version = env!("CARGO_PKG_VERSION");
-	println!(
-		"{} {} {} and serving requests: \n\n➜  {} {}",
-		rapid_logo(),
-		crate_version.bold(),
-		started_server_message(),
-		"Dev Server:".bold(),
+	info!(
+		"started rapid version {} server on {}",
+		crate_version,
 		server_url
 	);
-}
-
-pub fn clean_console() {
-	print!("{esc}c", esc = 27 as char);
-}
-
-pub fn rapid_log_target() -> GradientDisplay<'static, [RGB; 4]> {
-	let target = GradientStr::gradient(
-		&"[rapid-web::logger]",
-		[RGB::new(9, 42, 208), RGB::new(26, 78, 96), RGB::new(9, 42, 208), RGB::new(14, 197, 255)],
-	);
-	target
-}
-
-pub fn rapid_error(message: &str) {
-	println!("{}", message.color(Color::Red).bold());
 }

--- a/crates/rapid-web/src/tui.rs
+++ b/crates/rapid-web/src/tui.rs
@@ -1,14 +1,16 @@
 use colorful::{Color, Colorful};
+use rapid_cli::tui::rapid_logo;
 use std::env;
-use log::info;
 
 pub fn server_init(bind_config: (String, u16)) {
 	let server_url = format!("http://{}:{}", &bind_config.0, &bind_config.1).color(Color::Blue);
 	// Grab the current crate version at compile time...
 	let crate_version = env!("CARGO_PKG_VERSION");
-	info!(
-		"started rapid version {} server on {}",
-		crate_version,
+	println!(
+		"{} {} server running at: \n\n➜ {} {}",
+		rapid_logo(),
+		crate_version.bold(),
+		"local:".bold(),
 		server_url
 	);
 }

--- a/crates/rapid-web/src/util.rs
+++ b/crates/rapid-web/src/util.rs
@@ -1,7 +1,7 @@
-use super::{server::RAPID_SERVER_CONFIG, shift::util::is_valid_handler, tui::rapid_log_target};
+use super::{server::RAPID_SERVER_CONFIG, shift::util::is_valid_handler};
 use colorful::{Color, Colorful};
 use core::panic;
-use log::info;
+use log::warn;
 use rapid_cli::rapid_config::config::{RapidConfig, ServerConfig};
 use std::{env::current_dir, fs::File, io::Read, path::PathBuf};
 use syn::{parse_file, parse_str, File as SynFile, Item};
@@ -28,10 +28,8 @@ pub fn check_for_invalid_handlers(dir: &str) {
 			// Check if the handler is invalid (this is specifically for the actual function itself)
 			if !validate_route_handler(&file_contents) || !is_valid_route_function(&file_contents) {
 				// Show warning logs to the user as needed
-				println!("\n"); // Each log should have a indent of 1 so that we get some nice spacing
-				info!(
-					"{} Found invalid route handler file at {}",
-					rapid_log_target(),
+				warn!(
+					"found invalid route handler file at {}",
 					format!("`{}`", entry.path().to_str().expect("Error: could not parse invalid route handler")).color(Color::LightCyan)
 				);
 			}

--- a/examples/fullstackNextjs/Cargo.toml
+++ b/examples/fullstackNextjs/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 futures-util = "0.3.28"
 include_dir = "0.7.3"
-rapid-web = "0.4.6"
+rapid-web = { path = "../../crates/rapid-web" }
 
 # Rapid binary
 [[bin]]

--- a/examples/fullstackRemix/Cargo.toml
+++ b/examples/fullstackRemix/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 futures-util = "0.3.28"
 include_dir = "0.7.3"
-rapid-web = "0.4.5"
+rapid-web = { path = "../../crates/rapid-web" }
 
 # Rapid binary
 [[bin]]

--- a/examples/server/Cargo.toml
+++ b/examples/server/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 [dependencies]
 futures-util = "0.3.28"
 include_dir = "0.7.3"
-rapid-web = "0.4.6"
+rapid-web = { path = "../../crates/rapid-web" }


### PR DESCRIPTION
This is a refactor to move the logging towards utilzing the `log` macros instead of direct `println!` calls and generally make the experience better and more in line with other tools.

It removes the clearing of the screen in rapid-web which makes it much easier to use together with `next dev` for example (#56).

It changes the logger from env_logger to pretty_env_logger in both rapid-web and rapid-cli, and only uses `try_init` in the rapid-web crate so that it can be overriden by the end user, simply by initalizing their own logger first.

It removes the [rapid-web::logger] output since the logging crate can be adjusted to handle that information, if neccesarry. It also removes the `>>> R A P I D` output, to be more in line with how minimal other tools in the JS ecosystem are.

Removes `std::thread::sleep()` calls, as they just slow the process down without adding anything to the experience.


This PR on a more unrelated note also changes the rapid-web import in the examples to use local paths rather than pulling from crates.io.

Closes #56

~~This is currently a draft as the documentation has not been looked over and updated in the places that needs it.~~